### PR TITLE
Add usage example

### DIFF
--- a/src/examples/hello-build-with-workflow.yml
+++ b/src/examples/hello-build-with-workflow.yml
@@ -7,5 +7,7 @@ usage:
   orbs:
     hello-build: circleci/hello-build@0.0.8
 
-  jobs:
-    - hello-build/hello-build
+  workflows:
+    "Hello Workflow":
+        jobs:
+          - hello-build/hello-build

--- a/src/examples/hello-build-with-workflow.yml
+++ b/src/examples/hello-build-with-workflow.yml
@@ -1,6 +1,6 @@
 
 description: |
-  Invoke the hello-build orb.
+  Invoke and run the hello-build orb.
 usage:
   version: 2.1
 

--- a/src/examples/usage-example.yml
+++ b/src/examples/usage-example.yml
@@ -1,0 +1,11 @@
+
+description: |
+  Invoke the hello-build orb.
+usage:
+  version: 2.1
+
+  orbs:
+    hello-build: circleci/hello-build@0.0.8
+
+  jobs:
+    - hello-build/hello-build


### PR DESCRIPTION
**Purpose:**
This PR adds a quick usage example to the Hello-Build orb.

**Context:** 
The DX-Client team has been running UX sessions with first-time orb users, and those who select an orb with a usage example have far reduced errors. Our most recent session was with a junior developer who naturally gravitated towards the Hello orb as it was simplest, and then got very lost when this one did not have a usage example. 

The example I've added here is from the Using Orbs docs page: https://circleci.com/docs/2.0/using-orbs/
I changed 'hello' to 'hello-build' in the naming so as to reduce confusion when unfamiliar users look first at the Quick Start Guide, which uses 'hello-build'. 

@iynere would love your feedback on this. This may not be the best example to include, but I was hoping to reduce your time burden by rectifying the situation ourselves and this was the most obvious one. 