### PR TITLE
use bash4 as image, allow to parameter in job, fix arch command

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,17 +5,18 @@ description: |
 
 executors:
   default:
-    parameters:
-      tag:
-        type: string
-        default: "curl-browsers"
     docker:
-      - image:  circleci/buildpack-deps:<< parameters.tag >>
+      - image:  bash:4.4.19
 
 jobs:
   hello-build:
+    parameters:
+      to:
+        type: string
+        default: "${CIRCLE_USERNAME}"
     executor: default
     steps:
-      - hello-triggerer
+      - hello-triggerer:
+          to: <<parameters.to>>
       - circleci-env-highlights
       - system-info

--- a/src/commands/system-info.yml
+++ b/src/commands/system-info.yml
@@ -3,4 +3,4 @@ steps:
       name: "Show system information"
       command: |
         echo "uname:" $(uname -a)
-        echo "arch: " $(arch)
+        echo "arch: " $(uname -m)

--- a/src/examples/hello-build-with-workflow.yml
+++ b/src/examples/hello-build-with-workflow.yml
@@ -4,7 +4,7 @@ usage:
   version: 2.1
 
   orbs:
-    hello-build: circleci/hello-build@0.0.8
+    hello-build: circleci/hello-build@0.0.9
 
   workflows:
     "Hello Workflow":

--- a/src/examples/hello-build-with-workflow.yml
+++ b/src/examples/hello-build-with-workflow.yml
@@ -1,4 +1,3 @@
-
 description: |
   Invoke and run the hello-build orb.
 usage:


### PR DESCRIPTION
This PR replaces the `circleci/buildpack-deps` which typically takes 20+ seconds to start due to its low popularity, and replaces it with bash:4, which is very small and used by config error jobs, so likely to be cached.

As part of move I had to replace the `arch` command with `uname -m`, but output is the same.

Also I allowed the `to:` parameter to be passed from top level job.

Passing against my dev version with local build

<img width="714" alt="screen shot 2019-02-05 at 1 01 17 pm" src="https://user-images.githubusercontent.com/5262154/52294171-91147f80-2946-11e9-9f0e-1dd7c063a8f1.png">
